### PR TITLE
Use highlighter2 instead of highlighting-kate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 * New `git-todo` command shows todos based on git.
 
+* _Much_ faster. Now uses highlighter2 package instead of highlighting-kate.
+  (#22)
+
 ## 0.1.0 (2016-08-11)
 
 Complete rewrite in Haskell. Mostly command-line compatible with Python

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, base, bytestring, diff-parse, highlighting-kate
-, optparse-applicative, process, protolude, stdenv, tasty
-, tasty-hunit, text
+{ mkDerivation, base, bytestring, diff-parse, highlighter2
+, optparse-applicative, pretty-show, process, protolude, stdenv
+, tasty, tasty-hunit, text
 }:
 mkDerivation {
   pname = "difftodo";
@@ -9,13 +9,14 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base bytestring diff-parse highlighting-kate protolude text
+    base bytestring diff-parse highlighter2 protolude text
   ];
   executableHaskellDepends = [
     base bytestring optparse-applicative process protolude text
   ];
   testHaskellDepends = [
-    base bytestring highlighting-kate protolude tasty tasty-hunit text
+    base bytestring highlighter2 pretty-show protolude tasty
+    tasty-hunit text
   ];
   homepage = "https://github.com/jml/difftodo#readme";
   description = "Generate todo lists from source code";

--- a/difftodo.cabal
+++ b/difftodo.cabal
@@ -29,7 +29,7 @@ library
     , text
     , bytestring
     , diff-parse
-    , highlighting-kate
+    , highlighter2
   exposed-modules:
       Fixme
       Fixme.Comment
@@ -95,8 +95,9 @@ test-suite fixme-tests
     , protolude >= 0.1.5
     , text
     , bytestring
-    , highlighting-kate
     , difftodo
+    , highlighter2
+    , pretty-show
     , tasty
     , tasty-hunit
   other-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -23,7 +23,7 @@ library:
   dependencies:
     - bytestring
     - diff-parse
-    - highlighting-kate
+    - highlighter2
 
 executables:
   all-todos:
@@ -58,7 +58,8 @@ tests:
     source-dirs: tests
     dependencies:
       - bytestring
-      - highlighting-kate
       - difftodo
+      - highlighter2
+      - pretty-show
       - tasty
       - tasty-hunit

--- a/src/Fixme/Comment.hs
+++ b/src/Fixme/Comment.hs
@@ -1,16 +1,17 @@
 module Fixme.Comment
   ( -- * Understand comments
     Comment
-  , Located
   , parseComments
   , readComments
   , commentText
   , filename
   , startLine
   , endLine
+    -- ** Generic support for things located in files
+  , Located
+  , locatedValue
     -- ** Exposed for testing
   , newComment
-  , parseComments'
 
     -- * Understand programming languages
   , Language
@@ -21,26 +22,25 @@ module Fixme.Comment
 
 import Protolude
 
-import qualified Data.Text as Text
-import Data.Text.IO (readFile)
+import qualified Data.ByteString as ByteString
 import GHC.IO (FilePath)
-import Text.Highlighting.Kate
-  ( SourceLine
-  , Token
+import Text.Highlighter
+  ( lexerFromFilename
+  , runLexer
+  , Lexer
+  , Token(..)
   , TokenType(..)
-  , highlightAs
-  , languagesByFilename
   )
 
 
 -- | Given some source code, return a list of comments.
-parseComments :: Filename -> Language -> Text -> [Comment]
+parseComments :: Filename -> Language -> ByteString -> [Comment]
 parseComments filename language = parseComments' filename . highlightCode language
 
 -- | Given a consecutive sequence of lexed lines of source, return a list of
 -- all the comments found, along with the line number on which the comment
 -- starts.
-parseComments' :: Filename -> [SourceLine] -> [Comment]
+parseComments' :: Filename -> [Token] -> [Comment]
 parseComments' filename =
   coalesce appendComment . mapMaybe getComment . locateTokens filename
 
@@ -62,36 +62,43 @@ readComments filename =
   case languageForFile (toS filename) of
     Nothing -> Nothing
     Just language -> Just $ do
-      contents <- readFile filename
+      contents <- ByteString.readFile filename
       pure (parseComments (Just (toS filename)) language contents)
 
 
 -- | A thing that is located somewhere in a text file.
 data Located a = Located { filename :: Filename
                          , startLine :: Int
-                         , value :: a
+                         , locatedValue :: a
                          } deriving (Eq, Show)
+
+instance Functor Located where
+  fmap f (Located fn start x) = Located fn start (f x)
 
 -- | How we identify which blob of text a thing is located in.
 type Filename = Maybe Text
 
+locateTokens :: Filename -> [Token] -> [Located Token]
+locateTokens fn tokens =
+  [ Located fn i t | (i, t) <- zip startLines tokens ]
+  where
+    startLines = scanl (+) 0 [ numLines value | Token _ value <- tokens ]
 
-type LocatedToken = Located Token
+numLines :: ByteString -> Int
+numLines = ByteString.count newline
+  where newline = fromIntegral (ord '\n')
 
-locateTokens :: Filename -> [SourceLine] -> [LocatedToken]
-locateTokens fn lines = [Located fn i x | (i, xs) <- zip [0..] lines, x <- xs]
+type Comment = Located ByteString
 
+-- XXX: Rename commentText to be less misleading about type
+commentText :: Comment -> ByteString
+commentText = locatedValue
 
-type Comment = Located Text
-
-commentText :: Comment -> Text
-commentText = value
-
-newComment :: Filename -> Int -> Text -> Comment
+newComment :: Filename -> Int -> ByteString -> Comment
 newComment fn i text = Located fn i text
 
 endLine :: Comment -> Int
-endLine (Located _ startLine c) = startLine + (Text.count "\n" c)
+endLine (Located _ startLine c) = startLine + (numLines c)
 
 appendComment :: Comment -> Comment -> Maybe Comment
 appendComment x y
@@ -100,35 +107,33 @@ appendComment x y
   | startLine y - endLine x == 1 = Just (newComment (filename x) (startLine x) (commentText x <> "\n" <> commentText y))
   | otherwise = Just (newComment (filename x) (startLine x) (commentText x <> commentText y))
 
-getComment :: LocatedToken -> Maybe Comment
+getComment :: Located Token -> Maybe Comment
 getComment (Located filename lineNum token) =
   case getComment' token of
     Nothing -> Nothing
     Just comment -> Just $ Located filename lineNum comment
 
-getComment' :: Token -> Maybe Text
-getComment' (AlertTok, value) = Just (toS value)
-getComment' (CommentTok, value) = Just (toS value)
-getComment' _ = Nothing
+  where
+    getComment' :: Token -> Maybe ByteString
+    getComment' (Token tType value) = bool Nothing (Just value) (isComment tType)
+
+    isComment Comment = True
+    isComment (Arbitrary "Comment") = True
+    isComment (x :. y) = isComment x || isComment y
+    isComment _ = False
 
 
 -- | Wrappers around syntax highlighting code.
 
 -- TODO: Move these to a separate module, maybe.
 
-type Language = Text
+type Language = Lexer
 
-languageForFile :: Text -> Maybe Language
-languageForFile = fmap toS . head . languagesByFilename . toS
+languageForFile :: FilePath -> Maybe Language
+languageForFile = lexerFromFilename
 
-highlightCode :: Language -> Text -> [SourceLine]
+highlightCode :: Language -> ByteString -> [Token]
 highlightCode language code =
-  let highlighted = highlightAs (toS language) (toS code)
-  in case Text.toLower language of
-       "haskell" -> map fixupHaskellComments highlighted
-       _ -> highlighted
-
-  where
-    -- | For some reason, Kate highlights a Haskell comment with no text (i.e.
-    -- "--") as a function. Fix this up.
-    fixupHaskellComments = map (\t -> if t == (FunctionTok, "--") then (CommentTok, "--") else t)
+  case runLexer language code of
+    Left _ -> []
+    Right tokens -> tokens

--- a/src/Fixme/Diff.hs
+++ b/src/Fixme/Diff.hs
@@ -40,7 +40,7 @@ newCommentsFromDiff diff
     getNewCommentsForFile (FileDelta Deleted _ _ _) = Just []
     getNewCommentsForFile (FileDelta _ _ _ Binary) = Just []
     getNewCommentsForFile (FileDelta _ _ filename (Hunks hunks)) =
-      case languageForFile filename of
+      case languageForFile (toS filename) of
         Nothing -> Nothing
         Just language -> Just $ concatMap (getNewCommentsForHunk filename language) hunks
 
@@ -64,7 +64,7 @@ newCommentsFromDiff diff
 -- Here, "comment" means a contiguous sequence of comment tokens.
 getNewCommentsForHunk :: Text -> Language -> Hunk -> [Comment]
 getNewCommentsForHunk filename language hunk =
-  let comments = parseComments (Just filename) language afterText
+  let comments = parseComments (Just filename) language (toS afterText)
   in filterInsertions addedLineNumbers comments
   where
     -- | Reconstitute the "after" text of the diff hunk.

--- a/src/Fixme/Todo.hs
+++ b/src/Fixme/Todo.hs
@@ -8,15 +8,18 @@ module Fixme.Todo
 import Protolude
 
 import qualified Data.Text as Text
-import Fixme.Comment (Comment, Located, commentText, filename, startLine)
-
+import Fixme.Comment (Comment, Located, commentText, filename, startLine, locatedValue)
 
 type Todo = Located Text
 
+todoText :: Todo -> Text
+todoText = locatedValue
+
+
 getTodos :: Comment -> [Todo]
 getTodos comment =
-  if any (`Text.isInfixOf` commentText comment) defaultTags then
-    [comment] else []
+  if any (`Text.isInfixOf` (toS (commentText comment))) defaultTags then
+    [toS <$> comment] else []
 
 formatTodo :: Todo -> Text
 formatTodo todo =
@@ -24,7 +27,7 @@ formatTodo todo =
   where
     fn = maybe "<unknown>" identity (filename todo)
     lineNum = show (startLine todo)
-    indentedComment = Text.unlines (map ("  " <>) (Text.lines (commentText todo)))
+    indentedComment = Text.unlines (map ("  " <>) (Text.lines (todoText todo)))
 
 defaultTags :: [Text]
 defaultTags = [ "XXX"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -6,6 +6,7 @@ import Test.Tasty (defaultMain, TestTree, testGroup)
 
 import qualified Comment
 import qualified Diff
+import qualified Todo
 
 
 main :: IO ()
@@ -14,6 +15,7 @@ main = defaultMain tests
 tests :: TestTree
 tests =
   testGroup "Fixme"
-  [ Diff.tests
-  , Comment.tests
+  [ Comment.tests
+  , Diff.tests
+  , Todo.tests
   ]

--- a/tests/Todo.hs
+++ b/tests/Todo.hs
@@ -1,0 +1,23 @@
+module Todo (tests) where
+
+import Protolude
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+
+import Fixme.Comment (newComment)
+import Fixme.Todo (getTodos)
+
+tests :: TestTree
+tests =
+  testGroup "Fixme.Todo"
+  [ testCase "No todos" $ do
+      let comment = newComment (Just "somefile") 1 "# wolverhampton"
+      let expected = []
+      expected @=? getTodos comment
+  , testCase "One todo" $ do
+      let comment = newComment (Just "somefile") 1 "# TODO: wolverhampton"
+      let expected = []
+      let observed = getTodos comment
+      expected @=? observed
+  ]


### PR DESCRIPTION
Makes things _much_ faster. Fixes #22.

```
$ time git todo .
servant-docs/src/Servant/Docs/Internal.hs:799:
  -- TODO: We use 'AllMimeRender' here because we need to be able to show the
  -- example data. However, there's no reason to believe that the instances of
  -- 'AllMimeUnrender' and 'AllMimeRender' actually agree (or to suppose that
  -- both are even defined) for any particular type.

servant-js/src/Servant/JS/Internal.hs:105:
  -- | Attempts to reduce the function name provided to that allowed by @'Foreign'@.
  --
  -- https://mathiasbynens.be/notes/javascript-identifiers
  -- Couldn't work out how to handle zero-width characters.
  --
  -- @TODO: specify better default function name, or throw error?


real    0m5.009s
user    0m4.888s
sys 0m0.069s
```

(down from 5+ minutes, a 60x improvement).

```
time ../difftodo/dist/build/all-todos/all-todos servant-docs/src/Servant/Docs/Internal.hs servant-js/src/Servant/JS/Internal.hs
servant-docs/src/Servant/Docs/Internal.hs:799:
  -- TODO: We use 'AllMimeRender' here because we need to be able to show the
  -- example data. However, there's no reason to believe that the instances of
  -- 'AllMimeUnrender' and 'AllMimeRender' actually agree (or to suppose that
  -- both are even defined) for any particular type.

servant-js/src/Servant/JS/Internal.hs:105:
  -- | Attempts to reduce the function name provided to that allowed by @'Foreign'@.
  --
  -- https://mathiasbynens.be/notes/javascript-identifiers
  -- Couldn't work out how to handle zero-width characters.
  --
  -- @TODO: specify better default function name, or throw error?


real    0m0.126s
user    0m0.113s
sys 0m0.011s
```

(down from 0.471s, a 3x improvement).

It's still a little laggy, but now at least it's possible to use on larger code bases.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jml/difftodo/23)

<!-- Reviewable:end -->
