### PR TITLE
Git todo args

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Otherwise, `git todo` will show all TODOs between your branch and `master`.
 ### What do I need to do before merging this git branch?
 
 ```
-$ git todo
+$ git todo origin/master...
 git-todo/Main.hs:62:
   -- TODO: Take git diff flags as options
 
@@ -38,10 +38,16 @@ git-todo/Main.hs:90:
   -- TODO: Factor out todo reporting
 ```
 
+### Have I staged any TODOs?
+
+```
+$ git todo --cached
+```
+
 ### What TODOs are left in my code base?
 
 ```
-$ git todo .
+$ git todo --files
 ... too many to list here! ...
 ```
 

--- a/difftodo.cabal
+++ b/difftodo.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.13.0.
+-- This file has been generated from package.yaml by hpack version 0.14.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -103,4 +103,5 @@ test-suite fixme-tests
   other-modules:
       Comment
       Diff
+      Todo
   default-language: Haskell2010

--- a/git-todo/Main.hs
+++ b/git-todo/Main.hs
@@ -70,9 +70,9 @@ commentsFromDiff =
 
     -- TODO: Read this as a bytestring from the start
     loadDiff = do
-      d <- gitDiff Nothing
+      d <- gitDiff Nothing []
       if ByteString.null d
-        then gitDiff (Just "master...")
+        then gitDiff (Just "master...") []
         else pure d
 
 commentsFromFiles :: [FilePath] -> IO [Comment]
@@ -86,15 +86,13 @@ commentsFromFiles paths =
 -- TODO: Use gitlib
 
 -- | Run `git diff <diffspec>` in the current working directory.
-gitDiff :: Maybe Text -> IO ByteString
-gitDiff diffSpec =
-  toS <$> readProcess "git" ("diff":arg) ""
+gitDiff :: Maybe Text -> [Text] -> IO ByteString
+gitDiff commits paths =
+  toS <$> readProcess "git" ("diff":args) ""
   where
-    arg = maybeToList (toS <$> diffSpec)
+    args = toS <$> maybeToList commits <> ("--":paths)
 
 -- TODO: Factor out todo reporting
-
--- TODO: Kind of slow. About 3.7s on a git repo with 232 files.
 
 -- | Run `git ls-files` with the given files in the current working directory.
 gitListFiles :: [FilePath] -> IO [FilePath]

--- a/git-todo/Main.hs
+++ b/git-todo/Main.hs
@@ -60,6 +60,7 @@ options :: ParserInfo Config
 options =
   info (helper <*> parser) description
   where
+    -- TODO: Handle --cached flag.
     parser = Config <$> modeFlag <*> many (argument str (metavar "FILES..."))
     modeFlag = flag Diff Files (mconcat [ long "files"
                                         , short 'f'


### PR DESCRIPTION
Change `git-todo` to delegate argument parsing to git tools.

Means that:

```
$ git todo --cached HEAD^^ -- foo/bar
```

and

```
$ git todo origin/master...
```

now work.

Search files using:

```
$ git todo --files
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jml/difftodo/26)

<!-- Reviewable:end -->
